### PR TITLE
Bump beartype to 0.22.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "beartype>=0.19.0",
+    "beartype>=0.22.9",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.9.24",


### PR DESCRIPTION
Bump beartype dependency to 0.22.9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `beartype` runtime dependency to `>=0.22.9` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f47412b8b6951626c3f871bef178d90898209b9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->