### PR TITLE
Add ty to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,8 @@ ci:
     - pyright
     - pyright-docs
     - pyright-verifytypes
+    - ty
+    - ty-docs
     - pyroma
     - ruff-check-fix
     - ruff-check-fix-docs
@@ -335,6 +337,24 @@ repos:
         language: python
         pass_filenames: false
         types_or: [python]
+
+      - id: ty
+        name: ty
+        stages: [pre-push]
+        entry: uv run --extra=dev ty check
+        language: python
+        types_or: [python, toml]
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+
+      - id: ty-docs
+        name: ty-docs
+        stages: [pre-push]
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="ty check"
+        language: python
+        types_or: [markdown, rst]
+        additional_dependencies: [uv==0.9.5]
 
       - id: yamlfix
         name: yamlfix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ optional-dependencies.dev = [
     "sphinx-substitution-extensions==2025.11.17",
     "sphinxcontrib-spelling==8.0.2",
     "sybil==9.3.0",
+    "ty==0.0.1a34",
     "types-requests==2.32.4.20250913",
     "vulture==2.14",
     "vws-python-mock==2025.3.10.1",


### PR DESCRIPTION
Add ty and ty-docs hooks to pre-commit configuration.

This adds type checking with ty, following the pattern established in other repositories.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `ty` and `ty-docs` pre-push hooks and includes `ty` in dev dependencies.
> 
> - **Pre-commit**:
>   - Add `ty` and `ty-docs` hooks (pre-push) running `uv run --extra=dev ty check` and via `doccmd` for docs.
>   - Add `ty` and `ty-docs` to CI skip list.
> - **Dependencies**:
>   - Add `ty==0.0.1a34` to `optional-dependencies.dev` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b7fdc5593d1b43921b20f1598e115a082ee061f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->