### PR TITLE
chore: use deptry optional_dependencies_dev_groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,7 +276,7 @@ ignore = [
 ]
 
 [tool.deptry]
-pep621_dev_dependency_groups = [
+optional_dependencies_dev_groups = [
     "dev",
     "release",
 ]


### PR DESCRIPTION
Renames `pep621_dev_dependency_groups` to `optional_dependencies_dev_groups` for deptry 0.25+.

This removes deprecation warnings; the old key may be removed in a future deptry release.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `deptry` configuration key in `pyproject.toml`, affecting lint/tooling behavior but not runtime code.
> 
> **Overview**
> Updates `deptry` configuration to use the newer `optional_dependencies_dev_groups` key (replacing the deprecated `pep621_dev_dependency_groups`) so dev/release optional dependency groups are still recognized without deprecation warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90b3b8cb42e51d326117057f996593eb49a99da7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->