### PR TITLE
chore: define uv version once in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,7 +102,8 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: pydocstringformatter
@@ -110,7 +111,8 @@ repos:
         entry: uv run --extra=dev pydocstringformatter
         language: python
         types_or: [python]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: shellcheck
@@ -118,7 +120,8 @@ repos:
         entry: uv run --extra=dev shellcheck --shell=bash
         language: python
         types_or: [shell]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: shellcheck-docs
@@ -127,7 +130,8 @@ repos:
           --language=console --command="shellcheck --shell=bash"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: shfmt
@@ -135,7 +139,8 @@ repos:
         entry: shfmt --write --space-redirects --indent=4
         language: python
         types_or: [shell]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: shfmt-docs
@@ -144,7 +149,8 @@ repos:
           --no-pad-file --command="shfmt --write --space-redirects --indent=4"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: mypy
@@ -154,7 +160,8 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       # We do not use --example-workers 0 due to https://github.com/python/mypy/issues/18283
       - id: mypy-docs
@@ -170,7 +177,8 @@ repos:
         entry: uv run --extra=dev -m check_manifest
         language: python
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: pyright
         name: pyright
@@ -179,7 +187,8 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: pyright-docs
         name: pyright-docs
@@ -195,7 +204,8 @@ repos:
         language: python
         types_or: [python]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: vulture-docs
@@ -205,7 +215,8 @@ repos:
         language: python
         types_or: [python]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: pyroma
@@ -214,7 +225,8 @@ repos:
         language: python
         pass_filenames: false
         types_or: [toml]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: deptry
@@ -222,7 +234,8 @@ repos:
         entry: uv run --extra=dev -m deptry src/
         language: python
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: pylint
@@ -231,7 +244,8 @@ repos:
         language: python
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: pylint-docs
         name: pylint-docs
@@ -246,7 +260,8 @@ repos:
         entry: uv run --extra=dev -m ruff check --fix
         language: python
         types_or: [python]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: ruff-check-fix-docs
@@ -254,7 +269,8 @@ repos:
         entry: uv run --extra=dev doccmd --language=python --command="ruff check --fix"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: ruff-format-fix
@@ -262,7 +278,8 @@ repos:
         entry: uv run --extra=dev -m ruff format
         language: python
         types_or: [python]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: ruff-format-fix-docs
@@ -271,7 +288,8 @@ repos:
           format"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: doc8
@@ -279,7 +297,8 @@ repos:
         entry: uv run --extra=dev -m doc8
         language: python
         types_or: [rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: interrogate
@@ -287,7 +306,8 @@ repos:
         entry: uv run --extra=dev -m interrogate
         language: python
         types_or: [python]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: interrogate-docs
@@ -296,7 +316,8 @@ repos:
           --command="interrogate"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: pyproject-fmt-fix
@@ -315,7 +336,8 @@ repos:
         types_or: [rst]
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: spelling
         name: spelling
@@ -325,7 +347,8 @@ repos:
         types_or: [rst]
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: docs
         name: Build Documentation
@@ -333,7 +356,8 @@ repos:
         language: python
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: pyright-verifytypes
         name: pyright-verifytypes
@@ -350,7 +374,8 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: ty-docs
         name: ty-docs
@@ -359,7 +384,8 @@ repos:
           --command="ty check"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: pyrefly
         name: pyrefly
@@ -368,7 +394,8 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: pyrefly-docs
         name: pyrefly-docs
@@ -377,14 +404,16 @@ repos:
           --command="pyrefly check"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
 
       - id: yamlfix
         name: yamlfix
         entry: uv run --extra=dev yamlfix
         language: python
         types_or: [yaml]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: zizmor
@@ -393,7 +422,8 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: sphinx-lint
@@ -401,5 +431,6 @@ repos:
         entry: uv run --extra=dev sphinx-lint --enable=all --disable=line-too-long
         language: python
         types_or: [rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 ---
 fail_fast: true
 
+.uv_version: &uv_version uv==0.9.5
+
 # We use system Python, with required dependencies specified in pyproject.toml.
 # We therefore cannot use those dependencies in pre-commit CI.
 ci:
@@ -100,7 +102,7 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: pydocstringformatter
@@ -108,7 +110,7 @@ repos:
         entry: uv run --extra=dev pydocstringformatter
         language: python
         types_or: [python]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: shellcheck
@@ -116,7 +118,7 @@ repos:
         entry: uv run --extra=dev shellcheck --shell=bash
         language: python
         types_or: [shell]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: shellcheck-docs
@@ -125,7 +127,7 @@ repos:
           --language=console --command="shellcheck --shell=bash"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: shfmt
@@ -133,7 +135,7 @@ repos:
         entry: shfmt --write --space-redirects --indent=4
         language: python
         types_or: [shell]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: shfmt-docs
@@ -142,7 +144,7 @@ repos:
           --no-pad-file --command="shfmt --write --space-redirects --indent=4"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: mypy
@@ -152,7 +154,7 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       # We do not use --example-workers 0 due to https://github.com/python/mypy/issues/18283
       - id: mypy-docs
@@ -168,7 +170,7 @@ repos:
         entry: uv run --extra=dev -m check_manifest
         language: python
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pyright
         name: pyright
@@ -177,7 +179,7 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pyright-docs
         name: pyright-docs
@@ -193,7 +195,7 @@ repos:
         language: python
         types_or: [python]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: vulture-docs
@@ -203,7 +205,7 @@ repos:
         language: python
         types_or: [python]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: pyroma
@@ -212,7 +214,7 @@ repos:
         language: python
         pass_filenames: false
         types_or: [toml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: deptry
@@ -220,7 +222,7 @@ repos:
         entry: uv run --extra=dev -m deptry src/
         language: python
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: pylint
@@ -229,7 +231,7 @@ repos:
         language: python
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pylint-docs
         name: pylint-docs
@@ -244,7 +246,7 @@ repos:
         entry: uv run --extra=dev -m ruff check --fix
         language: python
         types_or: [python]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: ruff-check-fix-docs
@@ -252,7 +254,7 @@ repos:
         entry: uv run --extra=dev doccmd --language=python --command="ruff check --fix"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: ruff-format-fix
@@ -260,7 +262,7 @@ repos:
         entry: uv run --extra=dev -m ruff format
         language: python
         types_or: [python]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: ruff-format-fix-docs
@@ -269,7 +271,7 @@ repos:
           format"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: doc8
@@ -277,7 +279,7 @@ repos:
         entry: uv run --extra=dev -m doc8
         language: python
         types_or: [rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: interrogate
@@ -285,7 +287,7 @@ repos:
         entry: uv run --extra=dev -m interrogate
         language: python
         types_or: [python]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: interrogate-docs
@@ -294,7 +296,7 @@ repos:
           --command="interrogate"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: pyproject-fmt-fix
@@ -313,7 +315,7 @@ repos:
         types_or: [rst]
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: spelling
         name: spelling
@@ -323,7 +325,7 @@ repos:
         types_or: [rst]
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: docs
         name: Build Documentation
@@ -331,7 +333,7 @@ repos:
         language: python
         stages: [manual]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pyright-verifytypes
         name: pyright-verifytypes
@@ -348,7 +350,7 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: ty-docs
         name: ty-docs
@@ -357,7 +359,7 @@ repos:
           --command="ty check"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pyrefly
         name: pyrefly
@@ -366,7 +368,7 @@ repos:
         language: python
         types_or: [python, toml]
         pass_filenames: false
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: pyrefly-docs
         name: pyrefly-docs
@@ -375,14 +377,14 @@ repos:
           --command="pyrefly check"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
 
       - id: yamlfix
         name: yamlfix
         entry: uv run --extra=dev yamlfix
         language: python
         types_or: [yaml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: zizmor
@@ -391,7 +393,7 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: sphinx-lint
@@ -399,5 +401,5 @@ repos:
         entry: uv run --extra=dev sphinx-lint --enable=all --disable=line-too-long
         language: python
         types_or: [rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]


### PR DESCRIPTION
Matches the pattern from [literalizer](https://github.com/adamtheturtle/literalizer): a YAML anchor `.uv_version` so the uv pin is declared once and referenced as `*uv_version` in each hook's `additional_dependencies`.

`pre-commit validate-config` may warn about an unexpected root key `.uv_version`; that is expected and matches literalizer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that centralizes the `uv` version pin; main potential issue is tooling that rejects the extra root key or YAML anchor syntax.
> 
> **Overview**
> **Deduplicates the `uv` pin in `.pre-commit-config.yaml`.** Adds a top-level YAML anchor `.uv_version: &uv_version uv==0.9.5` and replaces repeated `additional_dependencies: [uv==0.9.5]` entries across local hooks with `additional_dependencies: [*uv_version]` to keep the version consistent in one place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6498524f6ecbb8d718493cb507cddfadfb37b728. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->