### PR TITLE
Enable mypy parallel workers in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,7 +156,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy
+        entry: uv run --extra=dev -m mypy --num-processes 4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -167,7 +167,8 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
+          --num-processes 4"
         language: python
         types_or: [markdown, rst]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,7 +156,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy --num-processes 4
+        entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -168,7 +168,7 @@ repos:
         name: mypy-docs
         stages: [pre-push]
         entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
-          --num-processes 4"
+          --num-workers=4"
         language: python
         types_or: [markdown, rst]
 


### PR DESCRIPTION
## Summary
- configure the `mypy` pre-push hook to run with `--num-processes 4`
- update `mypy-docs` to pass the same worker count inside the `--command` string for doccmd

## Test plan
- [x] run commit-time pre-commit hooks
- [x] run pre-push hooks during `git push`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change; it only affects local `pre-push` linting performance and could at worst surface mypy concurrency quirks.
> 
> **Overview**
> Updates the `pre-push` `mypy` hook to run with `--num-workers=4` for faster type-checking.
> 
> Makes the same worker setting apply to `mypy-docs` by embedding `--num-workers=4` into the `doccmd` `--command` string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a212cc3c3e4b9cf1e3862cb56a7c63f4a19a715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->