### PR TITLE
Add strict-kwargs pre-commit hook in fix mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ ci:
     - shfmt-docs
     - spelling
     - sphinx-lint
+    - strict-kwargs-fix
     - vulture
     - vulture-docs
     - yamlfix
@@ -292,6 +293,17 @@ repos:
         additional_dependencies:
           - *uv_version
         stages: [pre-commit]
+
+
+      - id: strict-kwargs-fix
+        name: strict-kwargs
+        entry: uv run --extra=dev strict-kwargs fix
+        language: python
+        types_or: [python]
+        additional_dependencies:
+          - *uv_version
+        stages: [pre-commit]
+        require_serial: true
 
       - id: doc8
         name: doc8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -294,7 +294,6 @@ repos:
           - *uv_version
         stages: [pre-commit]
 
-
       - id: strict-kwargs-fix
         name: strict-kwargs
         entry: uv run --extra=dev strict-kwargs fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ dynamic = [
 dependencies = [
     "beartype>=0.22.9",
 ]
-optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [
+    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ optional-dependencies.dev = [
     "vws-python-mock==2026.2.22.3",
     "yamlfix==1.19.1",
     "zizmor==1.25.1",
+
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://vws-python.github.io/vws-auth-tools/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,7 @@ dynamic = [
 dependencies = [
     "beartype>=0.22.9",
 ]
-optional-dependencies.dev = [
-    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,13 +68,13 @@ optional-dependencies.dev = [
     "sphinx-pyproject==0.3.0",
     "sphinx-substitution-extensions==2026.1.12",
     "sphinxcontrib-spelling==8.0.2",
+    "strict-kwargs==2026.5.18",
     "sybil==10.0.1",
     # Listed explicitly (despite being transitive via vws-python-mock) so that
     # [tool.uv.sources] can redirect to the CPU-only PyTorch index.
     # See: https://vws-python.github.io/vws-python-mock/installation.html#faster-installation
     "torch>=2.5.1",
     "torchvision>=0.20.1",
-    "strict-kwargs==2026.5.18",
     "ty==0.0.36",
     "types-requests==2.33.0.20260513",
     "vulture==2.16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ optional-dependencies.dev = [
     # See: https://vws-python.github.io/vws-python-mock/installation.html#faster-installation
     "torch>=2.5.1",
     "torchvision>=0.20.1",
+    "strict-kwargs==2026.5.18",
     "ty==0.0.36",
     "types-requests==2.33.0.20260513",
     "vulture==2.16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,6 @@ optional-dependencies.dev = [
     "vws-python-mock==2026.2.22.3",
     "yamlfix==1.19.1",
     "zizmor==1.25.1",
-
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://vws-python.github.io/vws-auth-tools/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ optional-dependencies.dev = [
     "sphinx-pyproject==0.3.0",
     "sphinx-substitution-extensions==2026.1.12",
     "sphinxcontrib-spelling==8.0.2",
-    "strict-kwargs==2026.5.18",
+    "strict-kwargs==2026.5.18.post1",
     "sybil==10.0.1",
     # Listed explicitly (despite being transitive via vws-python-mock) so that
     # [tool.uv.sources] can redirect to the CPU-only PyTorch index.


### PR DESCRIPTION
## Summary
- Add strict-kwargs pre-commit hook with fix mode.
- Skip in pre-commit CI.

## Test plan
- [ ] pre-commit run strict-kwargs --all-files

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only updates developer tooling (pre-commit) and adds a dev dependency; no runtime/auth logic is touched.
> 
> **Overview**
> Adds a new pre-commit hook, `strict-kwargs-fix`, which runs `strict-kwargs fix` on Python files (serially) to auto-apply strict-kwargs changes.
> 
> Updates the dev toolchain by adding `strict-kwargs` to `pyproject.toml` dev dependencies and skipping this hook in pre-commit CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6490790aa5eb52aeec5e81f0c8536b70c534749. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->