### PR TITLE
[codex] Fix doccmd generated file lint ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ optional-dependencies.dev = [
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",
-    "doccmd==2026.5.6",
+    "doccmd==2026.5.16",
     "freezegun==1.5.5",
     "furo==2025.12.19",
     "interrogate==1.7.0",
@@ -242,7 +242,9 @@ MESSAGES-CONTROL.disable = [
 MESSAGES-CONTROL.per-file-ignores = [
     "docs/source/conf.py:invalid-name",
     "docs/source/doccmd_*.py:invalid-name",
+    "docs/source/doccmd_*/*.py:invalid-name",
     "doccmd_README_rst_*.py:invalid-name",
+    "doccmd_*/*.py:invalid-name",
 ]
 # Spelling dictionary name. Available dictionaries: none. To make it working
 # install python-enchant package.


### PR DESCRIPTION
Bumps doccmd to 2026.5.16 and updates Pylint per-file ignores for the generated doccmd directory layout. The doccmd update now writes Python examples under hashed doccmd_* directories, so the previous flat-file invalid-name ignore no longer covered generated documentation snippets. This keeps the docs lint hook focused on project code while allowing lowercase globals in generated examples. Validated with the pylint-docs hook, pyproject-fmt, git diff --check, and the commit/push hook suites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only changes that adjust dev dependency and lint ignore globs; impact is limited to documentation generation/linting behavior.
> 
> **Overview**
> Updates the dev dependency `doccmd` to `2026.5.16`.
> 
> Adjusts Pylint `invalid-name` *per-file ignores* to also cover generated doccmd Python examples nested under `docs/source/doccmd_*/*.py` and `doccmd_*/*.py`, preventing docs lint failures after the generator’s new hashed directory structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27d91b0bb3c3d0c7910270b2e124ad5b98e4bab0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->