### PR TITLE
Add property-based authorization tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ optional-dependencies.dev = [
     "doccmd==2026.7.19",
     "freezegun==1.5.5",
     "furo==2025.12.19",
+    "hypothesis==6.165.0",
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.0",
     "mypy-strict-kwargs==2026.7.19.1",

--- a/tests/test_vws_auth_tools.py
+++ b/tests/test_vws_auth_tools.py
@@ -1,10 +1,14 @@
 """Tests for authorization tools."""
 
+import base64
 import datetime
+import hashlib
 from zoneinfo import ZoneInfo
 
 import pytest
 from freezegun import freeze_time
+from hypothesis import given
+from hypothesis import strategies as st
 
 import vws_auth_tools
 
@@ -70,11 +74,13 @@ def test_authorization_header(content: bytes | str) -> None:
     assert result == "VWS my_access_key:8Uy6SKuO5sSBY2X8/znlPFmDF/k="
 
 
-@pytest.mark.parametrize(argnames="content", argvalues=[b"", None])
-def test_authorization_header_none_content(content: bytes | None) -> None:
+@pytest.mark.parametrize(argnames="content", argvalues=[b"", "", None])
+def test_authorization_header_empty_content(
+    content: bytes | str | None,
+) -> None:
     """
-    The Authorization header is the same whether the content is None or
-    b"".
+    The Authorization header is the same for all empty content
+    values.
     """
     access_key = "my_access_key"
     # Ignore "Possible hardcoded password" as it is appropriate here.
@@ -95,3 +101,75 @@ def test_authorization_header_none_content(content: bytes | None) -> None:
     )
 
     assert result == "VWS my_access_key:XXvKyRyMkwS8/1P1WLQ0duqNpKs="
+
+
+@given(
+    access_key=st.text(),
+    secret_key=st.text(),
+    method=st.text(),
+    content=st.one_of(st.none(), st.binary(), st.text()),
+    content_type=st.text(),
+    date=st.text(),
+    request_path=st.text(),
+)
+def test_authorization_header_is_deterministic(
+    *,
+    access_key: str,
+    secret_key: str,
+    method: str,
+    content: bytes | str | None,
+    content_type: str,
+    date: str,
+    request_path: str,
+) -> None:
+    """Valid inputs always produce the same valid HMAC-SHA1 signature."""
+    first_result = vws_auth_tools.authorization_header(
+        access_key=access_key,
+        secret_key=secret_key,
+        method=method,
+        content=content,
+        content_type=content_type,
+        date=date,
+        request_path=request_path,
+    )
+    second_result = vws_auth_tools.authorization_header(
+        access_key=access_key,
+        secret_key=secret_key,
+        method=method,
+        content=content,
+        content_type=content_type,
+        date=date,
+        request_path=request_path,
+    )
+
+    assert first_result == second_result
+    prefix = f"VWS {access_key}:"
+    assert first_result.startswith(prefix)
+    signature = first_result.removeprefix(prefix)
+    digest_size = hashlib.sha1(usedforsecurity=False).digest_size
+    assert len(base64.b64decode(s=signature, validate=True)) == digest_size
+
+
+@given(content=st.text())
+def test_authorization_header_encodes_unicode_content(content: str) -> None:
+    """Unicode content is equivalent to its UTF-8 encoded bytes."""
+    string_result = vws_auth_tools.authorization_header(
+        access_key="my_access_key",
+        secret_key="my_secret_key",  # noqa: S106
+        method="HTTPMETHOD",
+        content=content,
+        content_type="some/content/type",
+        date="some_date_string",
+        request_path="/foo",
+    )
+    bytes_result = vws_auth_tools.authorization_header(
+        access_key="my_access_key",
+        secret_key="my_secret_key",  # noqa: S106
+        method="HTTPMETHOD",
+        content=content.encode(),
+        content_type="some/content/type",
+        date="some_date_string",
+        request_path="/foo",
+    )
+
+    assert string_result == bytes_result


### PR DESCRIPTION
Adds Hypothesis as a development dependency and property-based coverage for authorization header generation. The tests exercise arbitrary valid inputs, determinism, Base64-encoded HMAC-SHA1 output, Unicode-to-UTF-8 equivalence, arbitrary request paths, and all supported empty-content representations. Validated with the full test suite at 100% coverage plus the pre-commit, pre-push, and manual hook stages. Closes #1587.