### PR TITLE
Run shfmt through uv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -137,7 +137,7 @@ repos:
 
       - id: shfmt
         name: shfmt
-        entry: shfmt --write --space-redirects --indent=4
+        entry: uv run --extra=dev shfmt --write --space-redirects --indent=4
         language: python
         types_or: [shell]
         additional_dependencies:


### PR DESCRIPTION
## What changed

- Run the `shfmt` pre-commit hook through `uv run --extra=dev`.

## Why

The project already pins `shfmt-py` in its development dependencies. Invoking `shfmt` directly made this hook inconsistent with the other project-tool hooks and allowed an ambient executable to be used instead of the pinned development environment.

## Impact

The hook now uses the project-pinned `shfmt` version. Formatting behavior and arguments are unchanged.

## Validation

- `uv run --extra=dev shfmt --version`
- `uv run --extra=dev prek run shfmt --all-files`
- `git diff --check`
